### PR TITLE
Testing skeleton project: fixed failing end-to-end test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,7 @@ dependencies {
             'com.amazonaws:aws-java-sdk-s3:1.11.254',
             'com.amazonaws:aws-java-sdk-ecs:1.11.331',
             'ro.ghionoiu:queue-client:0.1.17',
-
-            'ro.ghionoiu:dev-screen-record:0.0.4',
-
+            
             'com.fasterxml.jackson.core:jackson-core:2.8.5',
             'com.fasterxml.jackson.core:jackson-databind:2.8.5',
             'com.fasterxml.jackson.core:jackson-annotations:2.8.5',

--- a/container/images/base/download_and_merge_video.sh
+++ b/container/images/base/download_and_merge_video.sh
@@ -25,7 +25,7 @@ ensure_env "SQS_REGION"
 ensure_env "SQS_QUEUE_URL"
 
 ensure_env "PARTICIPANT_ID"
-ensure_env "ROUND_ID"
+ensure_env "CHALLENGE_ID"
 
 echo  "~~~~~~ Download and merge video into accumulator ~~~~~~" > /dev/null
 ### --- do merge video and upload stuff here
@@ -36,7 +36,7 @@ VIDEO_LINK="http://some-url.com/video.mp4"
 
 if [[ "${SQS_QUEUE_URL}" != http* ]]; then
     echo "SQS_QUEUE_URL does not seem to be valid. Will print to the console and exit" > /dev/null
-    echo "participant=${PARTICIPANT_ID} roundId=${ROUND_ID} videoLink=${VIDEO_LINK}"
+    echo "participant=${PARTICIPANT_ID} challengeId=${CHALLENGE_ID} videoLink=${VIDEO_LINK}"
     exit 0
 fi
 
@@ -53,5 +53,5 @@ cat ${INTEROP_QUEUE_CONFIG}
 DRY_RUN=false java -Dconfig.file="${INTEROP_QUEUE_CONFIG}" \
     -jar "${WORK_DIR}/queue-cli-tool-all.jar" \
     send rawVideoUpdated \
-    participant=${PARTICIPANT_ID} roundId=${ROUND_ID} videoLink="${VIDEO_LINK}"
+    participant=${PARTICIPANT_ID} challengeId=${CHALLENGE_ID} videoLink="${VIDEO_LINK}"
 # Output: Public URL published to SQS or printed on the console

--- a/container/runDockerContainer.sh
+++ b/container/runDockerContainer.sh
@@ -10,9 +10,9 @@ BASE="base"
 export DEBUG="${DEBUG:-}"
 
 function die() { echo >&2 $1; exit 1; }
-[ "$#" -eq 2 ] || die "Usage: $0 PARTICIPANT_ID ROUND_ID"
+[ "$#" -eq 2 ] || die "Usage: $0 PARTICIPANT_ID CHALLENGE_ID"
 PARTICIPANT_ID=$1
-ROUND_ID=$2
+CHALLENGE_ID=$2
 
 echo "Compute base image name+version"
 DEFAULT_IMAGE_PREFIX="accelerate-io/dpnt-video-"
@@ -39,5 +39,5 @@ docker run                                                                      
       --env SQS_REGION=unused                                                   \
       --env SQS_QUEUE_URL=unused                                                \
       --env PARTICIPANT_ID=${PARTICIPANT_ID}                                    \
-      --env ROUND_ID=${ROUND_ID}                                                \
+      --env CHALLENGE_ID=${CHALLENGE_ID}                                        \
       ${base_image_tag}


### PR DESCRIPTION
There should be some message thrown into the logs when calling an API with incorrect parameters.

Only after running the below docker command:
```bash
DEBUG=true docker run -it  [AWS Params] \ 
--env PARTICIPANT_ID=66984a31a0cf4d21a79d6f48ae58dcb5 --env REPO=xxx \ 
--env CHALLENGE_ID=TCH accelerate-io/dpnt-video-base:latest
```
Did I see the error:
```
+ set -e
+ set -u
+ set -o pipefail
+++ dirname /srv/download_and_merge_video.sh
++ cd /srv
++ pwd
+ SCRIPT_CURRENT_DIR=/srv
+ WORK_DIR=/srv
+ ensure_env S3_ENDPOINT
+ '[' -z x ']'
+ ensure_env S3_REGION
+ '[' -z x ']'
+ ensure_env SQS_ENDPOINT
+ '[' -z x ']'
+ ensure_env SQS_REGION
+ '[' -z x ']'
+ ensure_env SQS_QUEUE_URL
+ '[' -z x ']'
+ ensure_env PARTICIPANT_ID
+ '[' -z x ']'
+ ensure_env ROUND_ID
+ '[' -z '' ']'
+ echo 'Environment variable ROUND_ID not set'
Environment variable ROUND_ID not set
```
How can we push this error so its visible in the logs and console?