### PR TITLE
Upgrade the base image from python 2.7 to python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,17 @@ The base container image needs to be build and tagged as `latest`:
 
 Start the local ECS simulator. The simulator will use the containers available in the local Docker registry.
 
-Try the below first:
+Try the below first (depending on the OS you are running on):
 
 ```bash 
 ping host.docker.internal
+ping docker.for.mac.host.internal
+ping docker.for.mac.localhost
+ping docker.for.win.host.internal
+ping docker.for.win.localhost
 ```
+
+Pick the one that is successful as a value the environment variable DOCKER_HOST_WITHIN_CONTAINER.
 
 ### Start the local ECS simulator (manually)
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ git submodule update --init
 
 ### Start the local S3 and SQS simulators (manually)
 ```bash
-python local-sqs/elasticmq-wrapper.py start
-python local-s3/minio-wrapper.py start config/local.params.yml
+python3.7 local-sqs/elasticmq-wrapper.py start
+python3.7 local-s3/minio-wrapper.py start config/local.params.yml
 ```
 
 The base container image needs to be build and tagged as `latest`:
@@ -44,7 +44,7 @@ ping host.docker.internal
 If there is response from the command in the previous section, then run the below command:
 
 ```bash
-python local-ecs/ecs-server-wrapper.py start config/local.params.yml
+python3.7 local-ecs/ecs-server-wrapper.py start config/local.params.yml
 ```
 
 Otherwise see below:
@@ -55,12 +55,12 @@ https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds.
 Also see https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-docker-for-mac-host-internal (especially for Windows or MacOS)
 If this is not supported on your machine, you have the option of changing the hostname used to locate the Docker host:
 ```bash
-DOCKER_HOST_WITHIN_CONTAINER=host.docker.internal python local-ecs/ecs-server-wrapper.py start config/local.params.yml
+DOCKER_HOST_WITHIN_CONTAINER=host.docker.internal python3.7 local-ecs/ecs-server-wrapper.py start config/local.params.yml
 ```
 or
 
 ```bash
-DOCKER_HOST_WITHIN_CONTAINER=n.n.n.n python local-ecs/ecs-server-wrapper.py start config/local.params.yml
+DOCKER_HOST_WITHIN_CONTAINER=n.n.n.n python3.7 local-ecs/ecs-server-wrapper.py start config/local.params.yml
 ```
 
 #### Linux

--- a/container/images/base/Dockerfile
+++ b/container/images/base/Dockerfile
@@ -1,8 +1,23 @@
-FROM java:8u111-jdk
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+FROM buildpack-deps:stretch-scm
 
-RUN apt-get update && apt-get install -qy \
-    python-pip    \
+# Install python 3.7 by copy installed layers from another image
+COPY --from=python:3.7 / /
+
+RUN python3 --version
+RUN pip --version
+
+# Install Java 8
+COPY --from=java:8u111-jdk /usr/lib/jvm /usr/lib/jvm
+
+ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+RUN echo "JAVA_HOME=${JAVA_HOME}"
+RUN echo "PATH=${PATH}"
+
+RUN rm -fr /var/lib/apt/lists/*
+
+RUN apt-get install --fix-missing && apt-get update && apt-get install -qy \
     libpython-dev \
     groff-base    \
     git           \

--- a/src/test/java/tdl/datapoint/video/VideoMergingAcceptanceTest.java
+++ b/src/test/java/tdl/datapoint/video/VideoMergingAcceptanceTest.java
@@ -35,8 +35,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class VideoMergingAcceptanceTest {
     private static final Context NO_CONTEXT = null;
-    private static final int WAIT_BEFORE_RETRY_IN_MILLIS = 2000;
-    private static final int TASK_FINISH_CHECK_RETRY_COUNT = 5;
+    private static final int WAIT_BEFORE_RETRY_IN_MILLIS = 3000;
+    private static final int TASK_FINISH_CHECK_RETRY_COUNT = 10;
 
     private static final String S3_VIDEO_CLIENT_UPLOAD_BUCKET = "tdl-test-video-upload";
     private static final String ACCUMULATOR_BUCKET = "tdl-test-video-accumulator";

--- a/startExternalDependencies.sh
+++ b/startExternalDependencies.sh
@@ -14,7 +14,7 @@ startLocalECS() {
             DOCKER_HOST_WITHIN_CONTAINER=172.17.0.1 python3.7 local-ecs/ecs-server-wrapper.py start config/local.params.yml
         fi
     else
-        python3.7 local-ecs/ecs-server-wrapper.py start config/local.params.yml
+        DOCKER_HOST_WITHIN_CONTAINER=docker.for.mac.host.internal python3.7 local-ecs/ecs-server-wrapper.py start config/local.params.yml
     fi
 }
 


### PR DESCRIPTION
Similar to the upgrade process on https://github.com/julianghionoiu/dpnt-coverage/pull/40, we have upgraded the container from python 2.7 to python 3.7

Additional fixes are related to acceptance execution and README docs fixes.